### PR TITLE
Fix legacy 4p slot serialization width

### DIFF
--- a/sts2-lan-connect/Scripts/LanConnectConstants.cs
+++ b/sts2-lan-connect/Scripts/LanConnectConstants.cs
@@ -16,8 +16,7 @@ internal static class LanConnectConstants
 
     public const int VanillaSlotIdBits = 2;
 
-    // Historical 0.2.2 releases used this slot bit-width on the wire.
-    public const int Legacy4pSlotIdBits = 8;
+    public const int Legacy4pSlotIdBits = VanillaSlotIdBits;
 
     public const int ExtendedSlotIdBits = 4;
 


### PR DESCRIPTION
## Summary
- restore the legacy_4p LobbyPlayer slot id width to the vanilla 2-bit layout
- prevent ClientLobbyJoinResponseMessage decoding from drifting into invalid ModelId values in 4-player rooms

## Testing
- dotnet build sts2-lan-connect/sts2_lan_connect.csproj with STS2 path overrides
- manual host/client verification: 4-player legacy room join no longer reports protocol incompatibility