### PR TITLE
fix: expose netId in room list for continue-run slot selection

### DIFF
--- a/lobby-service/src/server.ts
+++ b/lobby-service/src/server.ts
@@ -1442,7 +1442,7 @@ function toRoomListView(room: ReturnType<LobbyStore["listRooms"]>[number], inclu
     savedRun: room.savedRun
       ? {
           slots: room.savedRun.slots.map((slot) => ({
-            netId: includeSensitiveSavedRun ? slot.netId : "",
+            netId: slot.netId,
             characterId: slot.characterId,
             characterName: slot.characterName,
             playerName: includeSensitiveSavedRun ? slot.playerName : "",


### PR DESCRIPTION
## Summary

The `toRoomListView` function in `lobby-service/src/server.ts` was redacting `netId` to empty string for non-trusted clients (alongside `playerName`). However, `netId` is a numeric identifier required by joining players to select a saved-run slot via `desiredSavePlayerNetId`.

## Root Cause

`server.ts:1445`:
```typescript
// Before
netId: includeSensitiveSavedRun ? slot.netId : "",
```

This caused all saved-run slots to appear with empty `netId` in the room listing for non-authenticated clients. When a player tries to join:
1. Client sees all slots with `netId = ""`
2. Player selects a slot, client sends `desiredSavePlayerNetId = ""`
3. Server can't match any slot → falls through to `save_slot_required` error

## Fix

```typescript
// After
netId: slot.netId,
```

`netId` is a numeric identifier (e.g. `"1031249512057218517"`), not PII. It must always be visible for the continue-run slot selection to work.

## Test Plan

- [ ] Create a continue-run room as host
- [ ] Another player refreshes room list → savedRun slots show actual netIds (not empty)
- [ ] Joining player selects a slot → join succeeds without `save_slot_required`